### PR TITLE
Improved Run on Startup and Package Manager Update Logic

### DIFF
--- a/src/Core/Settings.cs
+++ b/src/Core/Settings.cs
@@ -50,8 +50,6 @@ namespace WinMemoryCleaner
 
         public static ModifierKeys OptimizationModifiers { get; set; }
 
-        public static string Path { get; set; }
-
         public static SortedSet<string> ProcessExclusionList { get; private set; }
 
         public static Enums.Priority RunOnPriority { get; set; }
@@ -168,8 +166,6 @@ namespace WinMemoryCleaner
                         if (Enum.TryParse(Convert.ToString(key.GetValue(Helper.NameOf(() => OptimizationModifiers), OptimizationModifiers), _culture), out optimizationModifiers) && optimizationModifiers.IsValid())
                             OptimizationModifiers = optimizationModifiers;
 
-                        Path = Convert.ToString(key.GetValue(Helper.NameOf(() => Path), Path), _culture);
-
                         Enums.Priority runOnPriority;
 
                         if (Enum.TryParse(Convert.ToString(key.GetValue(Helper.NameOf(() => RunOnPriority), RunOnPriority), _culture), out runOnPriority) && runOnPriority.IsValid())
@@ -264,7 +260,6 @@ namespace WinMemoryCleaner
                         key.SetValue(Helper.NameOf(() => MemoryAreas), (int)MemoryAreas);
                         key.SetValue(Helper.NameOf(() => OptimizationKey), (int)OptimizationKey);
                         key.SetValue(Helper.NameOf(() => OptimizationModifiers), (int)OptimizationModifiers);
-                        key.SetValue(Helper.NameOf(() => Path), Path);
                         key.SetValue(Helper.NameOf(() => RunOnStartup), RunOnStartup ? 1 : 0);
                         key.SetValue(Helper.NameOf(() => ShowOptimizationNotifications), ShowOptimizationNotifications ? 1 : 0);
                         key.SetValue(Helper.NameOf(() => ShowVirtualMemory), ShowVirtualMemory ? 1 : 0);

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -11,7 +11,7 @@ using WinMemoryCleaner;
 [assembly: AssemblyKeyFile(Constants.App.KeyFile)]
 [assembly: AssemblyProduct(Constants.App.Name)]
 [assembly: AssemblyTitle(Constants.App.Title)]
-[assembly: AssemblyVersion("3.0.0.0")]
+[assembly: AssemblyVersion("3.0.0.1")]
 [assembly: ComVisible(false)]
 [assembly: CLSCompliant(true)]
 [assembly: Guid(Constants.App.Id)]


### PR DESCRIPTION
## Summary

This pull request delivers two key improvements:
1.  A more robust "Run on Startup" feature that uses the Windows Task Scheduler directly for better reliability and permission handling.
2.  A refactored update mechanism that is compliant and consistent across our three supported package managers: **Chocolatey**, **Scoop**, and **WinGet**.

## Changes

* **`src/App.xaml.cs`**:
    * Enhanced the `RunOnStartup` method to create/delete a scheduled task with the highest privileges, ensuring the app starts correctly on logon.
    * Removed logic that saved the application's running path to the registry to ensure the package manager remains the single source of truth for the installation location.

* **For Chocolatey (`.github/workflows/chocolatey.yml`):**
    * The `chocolateyinstall.ps1` script now stops any running instance of the application before calling the `/Package` updater.

* **For Scoop (`.github/workflows/scoop.yml`):**
    * The manifest now uses Scoop's native `pre_update` and `post_update` hooks for the most reliable stop-update-restart experience.

* **For WinGet (`.github/workflows/winget.yml`):**
    * The manifest is now correctly configured to use `InstallerType: exe` with the `/Package` switch, matching the successful published version.

## Checklist

-   [x] My code follows the project’s coding style and conventions.
-   [x] I have tested the changes locally.
-   [x] This PR does not introduce any breaking changes for users.