### PR TITLE
fix: tray notification deadlock and monitor thread busy-spin

### DIFF
--- a/src/App.xaml.cs
+++ b/src/App.xaml.cs
@@ -23,11 +23,14 @@ namespace WinMemoryCleaner
     {
         #region Fields
 
+        private const int ShutdownWatchdogTimeoutMs = 8000;
         private static bool _isRunning;
         private static Mutex _mutex;
         private static NotifyIcon _notifyIcon;
         private static readonly List<string> _notifications = new List<string>();
         private static readonly object _showHidelock = new object();
+        private static System.Threading.Timer _shutdownWatchdog;
+        private static readonly object _shutdownWatchdogLock = new object();
 
         #endregion
 
@@ -901,13 +904,68 @@ namespace WinMemoryCleaner
             try
             {
                 if (force)
+                {
                     Environment.Exit(Constants.Windows.SystemErrorCode.ErrorSuccess);
+                    return;
+                }
+
+                ArmShutdownWatchdog();
+
+                var current = Current;
+
+                if (current == null || current.Dispatcher == null)
+                {
+                    Environment.Exit(Constants.Windows.SystemErrorCode.ErrorSuccess);
+                    return;
+                }
+
+                // Application.Shutdown has to run on the UI thread
+                if (current.Dispatcher.CheckAccess())
+                    current.Shutdown();
                 else
-                    Current.Shutdown();
+                    current.Dispatcher.BeginInvoke((Action)(() => current.Shutdown()));
             }
             catch
             {
                 Environment.Exit(Constants.Windows.SystemErrorCode.ErrorSuccess);
+            }
+        }
+
+        /// <summary>
+        /// Starts a timer that force-exits if a requested graceful shutdown does not complete.
+        /// </summary>
+        /// <remarks>
+        /// Runs on a pool thread so it stays alive even when the UI thread is stuck. Without
+        /// it, a shutdown that stalls leaves a process only Task Manager can end.
+        /// </remarks>
+        private static void ArmShutdownWatchdog()
+        {
+            try
+            {
+                lock (_shutdownWatchdogLock)
+                {
+                    if (_shutdownWatchdog != null)
+                        return;
+
+                    _shutdownWatchdog = new System.Threading.Timer(_ =>
+                    {
+                        try
+                        {
+                            Logger.Warning("Graceful shutdown did not complete in time. Forcing exit.");
+                            Logger.Dispose();
+                        }
+                        catch
+                        {
+                            // ignored
+                        }
+
+                        Environment.Exit(Constants.Windows.SystemErrorCode.ErrorSuccess);
+                    }, null, ShutdownWatchdogTimeoutMs, Timeout.Infinite);
+                }
+            }
+            catch
+            {
+                // ignored
             }
         }
 

--- a/src/Service/NotificationService.cs
+++ b/src/Service/NotificationService.cs
@@ -27,10 +27,19 @@ namespace WinMemoryCleaner
         private readonly object _disposeLock = new object();
 
         /// <summary>
-        /// Serializes GDI reads of the shared <see cref="_imageIcon" />, which the UI thread
-        /// (rotation tick) and the background monitor thread can both reach at once.
-        /// System.Drawing.Icon is not thread safe. Never held across a dispatcher call.
+        /// Serializes icon rendering. Held by both <see cref="GetRotatedIcon" /> and
+        /// <see cref="GetMemoryUsageIcon" />, which the UI thread (rotation tick) and the
+        /// background monitor threads can reach at the same time.
         /// </summary>
+        /// <remarks>
+        /// Rendering used to be serialized incidentally, because <see cref="Update" /> held
+        /// <see cref="_disposeLock" /> for its whole duration. That lock had to go to break the
+        /// deadlock described on <see cref="InvokeOnUi" />, so this one restores the guarantee
+        /// explicitly. It covers both render paths on purpose: GDI+ types are not thread safe,
+        /// and a partially covered invariant invites a future change to cache a Font, Brush or
+        /// StringFormat in a field and reintroduce a data race. Never held across a dispatcher
+        /// call.
+        /// </remarks>
         private readonly object _iconRenderLock = new object();
 
         /// <summary>
@@ -341,50 +350,53 @@ namespace WinMemoryCleaner
         {
             try
             {
-                using (var image = new Bitmap(16, 16))
-                using (var graphics = Graphics.FromImage(image))
-                using (var font = new Font("Consolas", 14F, FontStyle.Regular, GraphicsUnit.Pixel))
-                using (var format = new StringFormat())
-                using (var backgroundBrush = GetBackgroundBrush(memory, isOptimizing))
-                using (var textBrush = GetTextBrush(memory, isOptimizing))
+                lock (_iconRenderLock)
                 {
-                    // Configure format
-                    format.Alignment = StringAlignment.Center;
-                    format.LineAlignment = StringAlignment.Center;
-
-                    // Configure graphics quality
-                    graphics.InterpolationMode = InterpolationMode.HighQualityBicubic;
-                    graphics.PixelOffsetMode = PixelOffsetMode.HighQuality;
-                    graphics.SmoothingMode = SmoothingMode.AntiAlias;
-                    graphics.TextRenderingHint = TextRenderingHint.SingleBitPerPixelGridFit;
-
-                    // Draw background
-                    if (!Settings.TrayIconUseTransparentBackground)
+                    using (var image = new Bitmap(16, 16))
+                    using (var graphics = Graphics.FromImage(image))
+                    using (var font = new Font("Consolas", 14F, FontStyle.Regular, GraphicsUnit.Pixel))
+                    using (var format = new StringFormat())
+                    using (var backgroundBrush = GetBackgroundBrush(memory, isOptimizing))
+                    using (var textBrush = GetTextBrush(memory, isOptimizing))
                     {
-                        using (var path = new GraphicsPath())
+                        // Configure format
+                        format.Alignment = StringAlignment.Center;
+                        format.LineAlignment = StringAlignment.Center;
+
+                        // Configure graphics quality
+                        graphics.InterpolationMode = InterpolationMode.HighQualityBicubic;
+                        graphics.PixelOffsetMode = PixelOffsetMode.HighQuality;
+                        graphics.SmoothingMode = SmoothingMode.AntiAlias;
+                        graphics.TextRenderingHint = TextRenderingHint.SingleBitPerPixelGridFit;
+
+                        // Draw background
+                        if (!Settings.TrayIconUseTransparentBackground)
                         {
-                            path.AddArc(0, 0, 10, 10, 180, 90);
-                            path.AddArc(5, 0, 10, 10, 270, 90);
-                            path.AddArc(5, 5, 10, 10, 0, 90);
-                            path.AddArc(0, 5, 10, 10, 90, 90);
-                            path.CloseFigure();
+                            using (var path = new GraphicsPath())
+                            {
+                                path.AddArc(0, 0, 10, 10, 180, 90);
+                                path.AddArc(5, 0, 10, 10, 270, 90);
+                                path.AddArc(5, 5, 10, 10, 0, 90);
+                                path.AddArc(0, 5, 10, 10, 90, 90);
+                                path.CloseFigure();
 
-                            graphics.FillPath(backgroundBrush, path);
+                                graphics.FillPath(backgroundBrush, path);
+                            }
                         }
-                    }
 
-                    // Draw text
-                    graphics.DrawString(string.Format(CultureInfo.InvariantCulture, "{0:00}", memory.Physical.Used.Percentage == 100 ? 99 : memory.Physical.Used.Percentage), font, textBrush, 8F, 9F, format);
+                        // Draw text
+                        graphics.DrawString(string.Format(CultureInfo.InvariantCulture, "{0:00}", memory.Physical.Used.Percentage == 100 ? 99 : memory.Physical.Used.Percentage), font, textBrush, 8F, 9F, format);
 
-                    var handle = image.GetHicon();
+                        var handle = image.GetHicon();
 
-                    using (var icon = Icon.FromHandle(handle))
-                    {
-                        var clonedIcon = (Icon)icon.Clone();
+                        using (var icon = Icon.FromHandle(handle))
+                        {
+                            var clonedIcon = (Icon)icon.Clone();
 
-                        NativeMethods.DestroyIcon(handle);
+                            NativeMethods.DestroyIcon(handle);
 
-                        return clonedIcon;
+                            return clonedIcon;
+                        }
                     }
                 }
             }

--- a/src/Service/NotificationService.cs
+++ b/src/Service/NotificationService.cs
@@ -19,12 +19,33 @@ namespace WinMemoryCleaner
     {
         #region Fields
 
-        private int _currentRotationAngle;
+        private volatile int _currentRotationAngle;
         private Icon _currentIcon;
-        private bool _disposed;
+        private volatile bool _disposed;
         private readonly Icon _imageIcon;
         private readonly NotifyIcon _notifyIcon;
         private readonly object _disposeLock = new object();
+
+        /// <summary>
+        /// Serializes GDI reads of the shared <see cref="_imageIcon" />, which the UI thread
+        /// (rotation tick) and the background monitor thread can both reach at once.
+        /// System.Drawing.Icon is not thread safe. Never held across a dispatcher call.
+        /// </summary>
+        private readonly object _iconRenderLock = new object();
+
+        /// <summary>
+        /// Guards the <see cref="_currentIcon" /> swap. Normally that swap is serialized by
+        /// running on the UI thread, but when no dispatcher exists the work runs inline on the
+        /// calling thread, so concurrent callers could otherwise both dispose the same icon.
+        /// Only ever held for a field assignment; never across a dispatcher call.
+        /// </summary>
+        private readonly object _currentIconLock = new object();
+
+        /// <summary>
+        /// Owned by the UI thread. Only ever read or written inside a dispatcher callback,
+        /// which makes the UI thread the single point of truth and removes the need to hold
+        /// <see cref="_disposeLock" /> across a dispatcher call to keep it consistent.
+        /// </summary>
         private DispatcherTimer _rotationTimer;
 
         #endregion
@@ -106,19 +127,9 @@ namespace WinMemoryCleaner
                     _disposed = true;
                 }
 
-                try
-                {
-                    if (_rotationTimer != null)
-                    {
-                        _rotationTimer.Stop();
-                        _rotationTimer.Tick -= OnRotationTimerTick;
-                        _rotationTimer = null;
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Logger.Debug(ex);
-                }
+                // DispatcherTimer has thread affinity: Stop() from another thread throws, which
+                // previously left the timer running and kept firing ticks during shutdown.
+                InvokeOnUi(CleanupRotationTimer);
 
                 try
                 {
@@ -135,10 +146,13 @@ namespace WinMemoryCleaner
 
                 try
                 {
-                    if (_currentIcon != null && _currentIcon != _imageIcon)
+                    lock (_currentIconLock)
                     {
-                        _currentIcon.Dispose();
-                        _currentIcon = null;
+                        if (_currentIcon != null && _currentIcon != _imageIcon)
+                        {
+                            _currentIcon.Dispose();
+                            _currentIcon = null;
+                        }
                     }
                 }
                 catch (Exception ex)
@@ -171,6 +185,42 @@ namespace WinMemoryCleaner
         #endregion
 
         #region Methods
+
+        /// <summary>
+        /// Runs an action on the UI thread without ever blocking the calling thread.
+        /// </summary>
+        /// <remarks>
+        /// Must stay non-blocking. This used to be a blocking <c>Dispatcher.Invoke</c> reached
+        /// from <see cref="Update" /> on a background thread that held <see cref="_disposeLock" />,
+        /// while the UI thread took that same lock in <see cref="OnRotationTimerTick" />. Each
+        /// side then waited on the other (AB-BA), which froze the window and left a process that
+        /// only Task Manager could end. Both halves of that cycle are now gone, and using
+        /// <c>BeginInvoke</c> here is what keeps it from being reintroduced by a caller that
+        /// holds a lock.
+        /// </remarks>
+        /// <param name="action">The action to run on the UI thread.</param>
+        private static void InvokeOnUi(Action action)
+        {
+            if (action == null)
+                return;
+
+            try
+            {
+                var application = WpfApplication.Current;
+                var dispatcher = application == null ? null : application.Dispatcher;
+
+                // No dispatcher means there is no UI thread to marshal to, so running inline is
+                // both correct and necessary: returning here would silently drop the update.
+                if (dispatcher == null || dispatcher.CheckAccess())
+                    action();
+                else
+                    dispatcher.BeginInvoke(action);
+            }
+            catch (Exception ex)
+            {
+                Logger.Debug(ex);
+            }
+        }
 
         /// <summary>
         /// Cleans up the rotation timer resources and resets the rotation angle
@@ -357,34 +407,39 @@ namespace WinMemoryCleaner
 
             try
             {
-                using (var image = icon.ToBitmap())
-                using (var rotatedImage = new Bitmap(image.Width, image.Height))
-                using (var graphics = Graphics.FromImage(rotatedImage))
+                // icon is the shared _imageIcon; ToBitmap is a GDI read that must not run
+                // concurrently from the UI thread and the monitor thread.
+                lock (_iconRenderLock)
                 {
-                    // Configure graphics quality
-                    graphics.InterpolationMode = InterpolationMode.HighQualityBicubic;
-                    graphics.PixelOffsetMode = PixelOffsetMode.HighQuality;
-                    graphics.SmoothingMode = SmoothingMode.HighQuality;
-
-                    // Rotate around center point
-                    var centerX = image.Width / 2f;
-                    var centerY = image.Height / 2f;
-
-                    graphics.TranslateTransform(centerX, centerY);
-                    graphics.RotateTransform(angle);
-                    graphics.TranslateTransform(-centerX, -centerY);
-
-                    graphics.DrawImage(image, new Point(0, 0));
-
-                    var handle = rotatedImage.GetHicon();
-
-                    using (var tempIcon = Icon.FromHandle(handle))
+                    using (var image = icon.ToBitmap())
+                    using (var rotatedImage = new Bitmap(image.Width, image.Height))
+                    using (var graphics = Graphics.FromImage(rotatedImage))
                     {
-                        var clonedIcon = (Icon)tempIcon.Clone();
+                        // Configure graphics quality
+                        graphics.InterpolationMode = InterpolationMode.HighQualityBicubic;
+                        graphics.PixelOffsetMode = PixelOffsetMode.HighQuality;
+                        graphics.SmoothingMode = SmoothingMode.HighQuality;
 
-                        NativeMethods.DestroyIcon(handle);
+                        // Rotate around center point
+                        var centerX = image.Width / 2f;
+                        var centerY = image.Height / 2f;
 
-                        return clonedIcon;
+                        graphics.TranslateTransform(centerX, centerY);
+                        graphics.RotateTransform(angle);
+                        graphics.TranslateTransform(-centerX, -centerY);
+
+                        graphics.DrawImage(image, new Point(0, 0));
+
+                        var handle = rotatedImage.GetHicon();
+
+                        using (var tempIcon = Icon.FromHandle(handle))
+                        {
+                            var clonedIcon = (Icon)tempIcon.Clone();
+
+                            NativeMethods.DestroyIcon(handle);
+
+                            return clonedIcon;
+                        }
                     }
                 }
             }
@@ -476,16 +531,24 @@ namespace WinMemoryCleaner
         /// <param name="running">if set to <c>true</c> shows loading cursor and disables menu</param>
         public void Loading(bool running)
         {
-            if (WpfApplication.Current == null || WpfApplication.Current.Dispatcher == null)
-                return;
-
-            // Multi-threading trick
-            WpfApplication.Current.Dispatcher.Invoke((Action)delegate
+            // Non-blocking: this is called from background threads that hold locks (the
+            // optimization path sets IsBusy while holding the view model lock).
+            InvokeOnUi(() =>
             {
-                Mouse.OverrideCursor = running ? Cursors.Wait : null;
+                try
+                {
+                    if (_disposed)
+                        return;
 
-                if (_notifyIcon.ContextMenuStrip != null)
-                    _notifyIcon.ContextMenuStrip.Enabled = !running;
+                    Mouse.OverrideCursor = running ? Cursors.Wait : null;
+
+                    if (_notifyIcon != null && _notifyIcon.ContextMenuStrip != null)
+                        _notifyIcon.ContextMenuStrip.Enabled = !running;
+                }
+                catch (Exception ex)
+                {
+                    Logger.Debug(ex);
+                }
             });
         }
 
@@ -501,17 +564,25 @@ namespace WinMemoryCleaner
             if (_notifyIcon == null)
                 return;
 
-            try
+            // Marshalled: the optimization path calls this from a background thread, and
+            // NotifyIcon.Visible / ShowBalloonTip must run on the thread that owns the icon.
+            InvokeOnUi(() =>
             {
-                _notifyIcon.Visible = false;
-                _notifyIcon.Visible = true;
+                try
+                {
+                    if (_disposed || _notifyIcon == null)
+                        return;
 
-                _notifyIcon.ShowBalloonTip(timeout * 1000, title, message, (ToolTipIcon)icon);
-            }
-            catch (Exception ex)
-            {
-                Logger.Debug(ex);
-            }
+                    _notifyIcon.Visible = false;
+                    _notifyIcon.Visible = true;
+
+                    _notifyIcon.ShowBalloonTip(timeout * 1000, title, message, (ToolTipIcon)icon);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Debug(ex);
+                }
+            });
         }
 
         /// <summary>
@@ -521,41 +592,24 @@ namespace WinMemoryCleaner
         /// <param name="e">The event arguments</param>
         private void OnRotationTimerTick(object sender, EventArgs e)
         {
-            lock (_disposeLock)
+            // Already on the UI thread. Taking _disposeLock here is what let a background
+            // thread inside Update block the UI thread, so the lock is deliberately absent.
+            if (_disposed)
+                return;
+
+            try
             {
-                if (_disposed)
-                    return;
+                _currentRotationAngle = (_currentRotationAngle + 90) % 360;
 
-                try
-                {
-                    _currentRotationAngle = (_currentRotationAngle + 90) % 360;
-
-                    var newIcon = GetRotatedIcon(_imageIcon, _currentRotationAngle);
-                    var oldIcon = _currentIcon;
-
-                    _notifyIcon.Icon = newIcon;
-                    _currentIcon = newIcon;
-
-                    if (oldIcon != null && oldIcon != _imageIcon && oldIcon != newIcon)
-                    {
-                        try
-                        {
-                            oldIcon.Dispose();
-                        }
-                        catch
-                        {
-                            // ignored
-                        }
-                    }
-                }
-                catch (ObjectDisposedException)
-                {
-                    // Already disposed, ignore
-                }
-                catch (Exception ex)
-                {
-                    Logger.Debug(ex);
-                }
+                ApplyIcon(_notifyIcon.Text, GetRotatedIcon(_imageIcon, _currentRotationAngle));
+            }
+            catch (ObjectDisposedException)
+            {
+                // Already disposed, ignore
+            }
+            catch (Exception ex)
+            {
+                Logger.Debug(ex);
             }
         }
 
@@ -564,34 +618,25 @@ namespace WinMemoryCleaner
         /// </summary>
         private void StartRotationAnimation()
         {
-            if (_rotationTimer != null)
-                return;
-
-            if (WpfApplication.Current == null || WpfApplication.Current.Dispatcher == null)
-                return;
-
-            try
+            InvokeOnUi(() =>
             {
-                WpfApplication.Current.Dispatcher.Invoke((Action)delegate
+                try
                 {
-                    try
-                    {
-                        _currentRotationAngle = 0;
+                    // Checked on the UI thread so two concurrent starts cannot both create a timer
+                    if (_rotationTimer != null || _disposed)
+                        return;
 
-                        _rotationTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(200) };
-                        _rotationTimer.Tick += OnRotationTimerTick;
-                        _rotationTimer.Start();
-                    }
-                    catch (Exception ex)
-                    {
-                        Logger.Debug(ex);
-                    }
-                });
-            }
-            catch (Exception ex)
-            {
-                Logger.Debug(ex);
-            }
+                    _currentRotationAngle = 0;
+
+                    _rotationTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(200) };
+                    _rotationTimer.Tick += OnRotationTimerTick;
+                    _rotationTimer.Start();
+                }
+                catch (Exception ex)
+                {
+                    Logger.Debug(ex);
+                }
+            });
         }
 
         /// <summary>
@@ -599,26 +644,11 @@ namespace WinMemoryCleaner
         /// </summary>
         private void StopRotationAnimation()
         {
-            if (_rotationTimer == null)
-                return;
-
-            try
-            {
-                if (WpfApplication.Current == null || WpfApplication.Current.Dispatcher == null)
-                {
-                    CleanupRotationTimer();
-                    return;
-                }
-
-                WpfApplication.Current.Dispatcher.Invoke((Action)delegate
-                {
-                    CleanupRotationTimer();
-                });
-            }
-            catch (Exception ex)
-            {
-                Logger.Debug(ex);
-            }
+            // No _rotationTimer check here on purpose. The field is owned by the UI thread and
+            // is not volatile, so a caller on another thread can read a stale null and skip the
+            // cleanup, leaving the animation running. CleanupRotationTimer does the null check
+            // on the UI thread, where the read is valid.
+            InvokeOnUi(CleanupRotationTimer);
         }
 
         /// <summary>
@@ -632,41 +662,82 @@ namespace WinMemoryCleaner
             if (memory == null)
                 throw new ArgumentNullException("memory");
 
-            lock (_disposeLock)
+            if (_disposed || _notifyIcon == null)
+                return;
+
+            string text;
+            Icon newIcon;
+
+            // Rendering happens on the calling thread, outside any lock, so a slow GDI draw
+            // never stalls the UI thread and never blocks a lock the UI thread needs.
+            try
+            {
+                text = GetText(memory, isOptimizing);
+                newIcon = GetIcon(memory, isOptimizing);
+            }
+            catch (Exception ex)
+            {
+                Logger.Debug(ex);
+                return;
+            }
+
+            // NotifyIcon has thread affinity: its window was created on the UI thread, so
+            // assigning Text/Icon from a pool thread can hang on the shell notification call.
+            InvokeOnUi(() => ApplyIcon(text, newIcon));
+        }
+
+        /// <summary>
+        /// Assigns the tray icon text and image, then releases the icon it replaced.
+        /// </summary>
+        /// <remarks>
+        /// Normally invoked on the UI thread. When no dispatcher exists it runs inline on the
+        /// calling thread instead, so the icon swap is guarded by <see cref="_currentIconLock" />
+        /// rather than relying on UI-thread serialization.
+        /// </remarks>
+        /// <param name="text">The tooltip text.</param>
+        /// <param name="newIcon">The icon to display.</param>
+        private void ApplyIcon(string text, Icon newIcon)
+        {
+            try
             {
                 if (_disposed || _notifyIcon == null)
-                    return;
-
-                try
                 {
-                    _notifyIcon.Text = GetText(memory, isOptimizing);
+                    if (newIcon != null && newIcon != _imageIcon)
+                        newIcon.Dispose();
 
-                    var newIcon = GetIcon(memory, isOptimizing);
-                    var oldIcon = _currentIcon;
+                    return;
+                }
 
+                Icon oldIcon;
+
+                lock (_currentIconLock)
+                {
+                    oldIcon = _currentIcon;
+
+                    _notifyIcon.Text = text;
                     _notifyIcon.Icon = newIcon;
                     _currentIcon = newIcon;
+                }
 
-                    if (oldIcon != null && oldIcon != _imageIcon && oldIcon != newIcon)
+                if (oldIcon != null && oldIcon != _imageIcon && oldIcon != newIcon)
+                {
+                    try
                     {
-                        try
-                        {
-                            oldIcon.Dispose();
-                        }
-                        catch
-                        {
-                            // ignored
-                        }
+                        oldIcon.Dispose();
+                    }
+                    catch
+                    {
+                        // ignored
                     }
                 }
-                catch (ObjectDisposedException)
-                {
-                    // Already disposed, ignore
-                }
-                catch (Exception ex)
-                {
-                    Logger.Debug(ex);
-                }
+            }
+            catch (ObjectDisposedException)
+            {
+                // Already disposed, ignore
+            }
+            catch (Exception ex)
+            {
+                Logger.Debug(ex);
             }
         }
 

--- a/src/Test/ServiceTests.cs
+++ b/src/Test/ServiceTests.cs
@@ -338,7 +338,114 @@ namespace WinMemoryCleaner.Test
 
                 Assert.DoesNotThrow(() => _notificationService.Dispose());
             }
-            
+
+            // Regression tests for the tray-icon freeze. Update used to hold a lock across a
+            // blocking dispatcher call while the UI thread took the same lock, which deadlocked
+            // the window and left a process only Task Manager could end.
+
+            [Test]
+            public void Update_FromManyThreadsConcurrently_DoesNotDeadlockOrThrow()
+            {
+                var memory = new Memory(Mocker.CreateMemoryStatusEx());
+                var showMemoryUsage = Settings.TrayIconShowMemoryUsage;
+
+                try
+                {
+                    // false routes through the rotation-animation path, which is the default
+                    // and the one that used to block on the dispatcher
+                    Settings.TrayIconShowMemoryUsage = false;
+
+                    var errors = new System.Collections.Concurrent.ConcurrentQueue<Exception>();
+                    var threads = new System.Collections.Generic.List<System.Threading.Thread>();
+
+                    for (var i = 0; i < 8; i++)
+                    {
+                        var optimizing = i % 2 == 0;
+                        var thread = new System.Threading.Thread(() =>
+                        {
+                            try
+                            {
+                                for (var j = 0; j < 25; j++)
+                                    _notificationService.Update(memory, optimizing);
+                            }
+                            catch (Exception e)
+                            {
+                                errors.Enqueue(e);
+                            }
+                        });
+
+                        thread.IsBackground = true;
+                        threads.Add(thread);
+                    }
+
+                    foreach (var thread in threads)
+                        thread.Start();
+
+                    foreach (var thread in threads)
+                        Assert.IsTrue(thread.Join(TimeSpan.FromSeconds(30)), "Update blocked; a caller is waiting on a lock or the dispatcher.");
+
+                    Assert.IsEmpty(errors.ToArray());
+
+                    // An unsynchronized icon swap can leave the icon that is still assigned to
+                    // the tray disposed. Touching Handle on a disposed Icon throws.
+                    var assigned = _notifyIcon.Icon;
+
+                    if (assigned != null)
+                        Assert.DoesNotThrow(() => { var unused = assigned.Handle; }, "The icon assigned to the tray was disposed by a concurrent update.");
+                }
+                finally
+                {
+                    Settings.TrayIconShowMemoryUsage = showMemoryUsage;
+                }
+            }
+
+            [Test]
+            public void Update_WhileDisposing_DoesNotThrow()
+            {
+                var memory = new Memory(Mocker.CreateMemoryStatusEx());
+                var errors = new System.Collections.Concurrent.ConcurrentQueue<Exception>();
+
+                var updater = new System.Threading.Thread(() =>
+                {
+                    try
+                    {
+                        for (var i = 0; i < 200; i++)
+                            _notificationService.Update(memory, i % 2 == 0);
+                    }
+                    catch (Exception e)
+                    {
+                        errors.Enqueue(e);
+                    }
+                });
+
+                updater.IsBackground = true;
+                updater.Start();
+
+                Assert.DoesNotThrow(() => _notificationService.Dispose());
+                Assert.IsTrue(updater.Join(TimeSpan.FromSeconds(30)), "Update did not finish while the service was disposed.");
+                Assert.IsEmpty(errors.ToArray());
+            }
+
+            [Test]
+            public void Loading_FromBackgroundThread_DoesNotBlock()
+            {
+                var completed = false;
+
+                var worker = new System.Threading.Thread(() =>
+                {
+                    _notificationService.Loading(true);
+                    _notificationService.Loading(false);
+                    completed = true;
+                });
+
+                worker.IsBackground = true;
+                worker.Start();
+
+                Assert.IsTrue(worker.Join(TimeSpan.FromSeconds(10)), "Loading blocked the calling thread.");
+                Assert.IsTrue(completed);
+            }
+
+
             public void Dispose()
             {
                 // Ensure teardown logic runs when used as IDisposable

--- a/src/View/Window/MainWindow.xaml.cs
+++ b/src/View/Window/MainWindow.xaml.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using System.Threading;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
@@ -213,8 +212,21 @@ namespace WinMemoryCleaner
                 }
                 else
                 {
-                    Thread.Sleep(1000);
-                    App.Shutdown();
+                    // This runs on the UI thread, so sleeping here froze the window for a full
+                    // second after every optimization. A timer gives the same grace period
+                    // (letting the tray notification appear) while the UI keeps pumping.
+                    var shutdownDelay = new System.Windows.Threading.DispatcherTimer
+                    {
+                        Interval = TimeSpan.FromMilliseconds(1000)
+                    };
+
+                    shutdownDelay.Tick += (sender, args) =>
+                    {
+                        shutdownDelay.Stop();
+                        App.Shutdown();
+                    };
+
+                    shutdownDelay.Start();
                 }
             }
             else

--- a/src/ViewModel/Base/ViewModel.cs
+++ b/src/ViewModel/Base/ViewModel.cs
@@ -10,7 +10,11 @@ namespace WinMemoryCleaner
     {
         #region Fields
 
-        private bool _isBusy;
+        /// <summary>
+        /// Written on the UI thread, polled by the background monitor loops, so the write has
+        /// to be visible to them without a lock.
+        /// </summary>
+        private volatile bool _isBusy;
 
         #endregion
 

--- a/src/ViewModel/MainViewModel.cs
+++ b/src/ViewModel/MainViewModel.cs
@@ -1476,12 +1476,30 @@ namespace WinMemoryCleaner
                         // ignored
                     }
 
-                    // The source is deliberately not disposed. The monitor loops hold its token
-                    // and wait on its handle; disposing it out from under a loop that has not
-                    // observed the cancellation yet throws ObjectDisposedException from the
-                    // loop condition, which is outside the try block and would take down the
-                    // pool thread. Cancel() is enough to end the loops, and the handle is
-                    // reclaimed when the process exits moments later.
+                    // RC1 captured the token once into a local at loop entry, which makes
+                    // IsCancellationRequested safe to read after the source is disposed
+                    // (the token is a struct, doesn't throw). Before RC1, the loop read
+                    // _cancellationTokenSource.Token fresh in the while condition, which
+                    // could throw ObjectDisposedException on a pool thread after disposal.
+                    // With the local capture, disposing is safe. Wait briefly for loops
+                    // to observe cancellation, then dispose.
+                    try
+                    {
+                        _cancellationTokenSource.Token.WaitHandle.WaitOne(100);
+                    }
+                    catch
+                    {
+                        // ignored
+                    }
+
+                    try
+                    {
+                        _cancellationTokenSource.Dispose();
+                    }
+                    catch
+                    {
+                        // ignored
+                    }
                 }
 
                 if (_hotKeyService != null)

--- a/src/ViewModel/MainViewModel.cs
+++ b/src/ViewModel/MainViewModel.cs
@@ -1476,23 +1476,12 @@ namespace WinMemoryCleaner
                         // ignored
                     }
 
-                    try
-                    {
-                        _cancellationTokenSource.Token.WaitHandle.WaitOne(100);
-                    }
-                    catch
-                    {
-                        // ignored
-                    }
-
-                    try
-                    {
-                        _cancellationTokenSource.Dispose();
-                    }
-                    catch
-                    {
-                        // ignored
-                    }
+                    // The source is deliberately not disposed. The monitor loops hold its token
+                    // and wait on its handle; disposing it out from under a loop that has not
+                    // observed the cancellation yet throws ObjectDisposedException from the
+                    // loop condition, which is outside the try block and would take down the
+                    // pool thread. Cancel() is enough to end the loops, and the handle is
+                    // reclaimed when the process exits moments later.
                 }
 
                 if (_hotKeyService != null)
@@ -1613,17 +1602,23 @@ namespace WinMemoryCleaner
         /// </summary>
         private void MonitorApp()
         {
-            while (!_cancellationTokenSource.Token.IsCancellationRequested)
+            // Captured once: the token is read after Dispose may have disposed its source,
+            // and CancellationToken stays usable while CancellationTokenSource does not.
+            var token = _cancellationTokenSource.Token;
+
+            while (!token.IsCancellationRequested)
             {
                 try
                 {
+                    // Delay first, unconditionally. Skipping this wait when IsBusy was set
+                    // turned the loop into a busy-spin that pinned a CPU core for as long as
+                    // the app stayed busy, which is most of an optimization run.
+                    if (token.WaitHandle.WaitOne(60000))
+                        break;
+
                     // Check if it's busy
                     if (IsBusy)
                         continue;
-
-                    // Delay
-                    if (_cancellationTokenSource.Token.WaitHandle.WaitOne(60000))
-                        break;
 
                     // Update app
                     Updater.Update();
@@ -1700,27 +1695,31 @@ namespace WinMemoryCleaner
             // App priority
             App.SetPriority(Settings.RunOnPriority);
 
-            while (!_cancellationTokenSource.Token.IsCancellationRequested)
+            // Captured once, for the same reason as in MonitorApp
+            var token = _cancellationTokenSource.Token;
+
+            while (!token.IsCancellationRequested)
             {
                 try
                 {
-                    // Check if it's busy
-                    if (IsBusy)
-                        continue;
-
-                    lock (_lockObject)
+                    // Check if it's busy. The delay below always runs, so a busy app makes this
+                    // loop idle rather than spin.
+                    if (!IsBusy)
                     {
-                        // Update memory info
-                        Computer.Memory = _computerService.Memory;
+                        lock (_lockObject)
+                        {
+                            // Update memory info
+                            Computer.Memory = _computerService.Memory;
 
-                        RaisePropertyChanged(() => Computer);
-                        RaisePropertyChanged(() => VirtualMemoryHeader);
+                            RaisePropertyChanged(() => Computer);
+                            RaisePropertyChanged(() => VirtualMemoryHeader);
 
-                        NotificationService.Update(Computer.Memory, IsOptimizationRunning);
+                            NotificationService.Update(Computer.Memory, IsOptimizationRunning);
+                        }
                     }
 
                     // Delay
-                    if (_cancellationTokenSource.Token.WaitHandle.WaitOne(5000))
+                    if (token.WaitHandle.WaitOne(5000))
                         break;
                 }
                 catch (Exception e)


### PR DESCRIPTION
## Summary

Fixes a lock-ordering (AB-BA) deadlock around the tray icon that leaves the window unresponsive and the process unable to exit, plus a busy-spin in both background monitor loops.

This addresses the freeze described in #183 / #190 (GUI unresponsive, cannot exit from the tray, only Task Manager works). Please see the note at the bottom — I do **not** believe it explains every report in those threads.

## Related Issue

Relates to #183, #190, #192

## Changes

### The deadlock

`NotificationService.Update` runs on a background monitor thread. It took `_disposeLock`, then reached a **blocking** `Dispatcher.Invoke` via `GetIcon` → `GetImageIcon` → `Start`/`StopRotationAnimation`. Meanwhile the UI thread took that same `_disposeLock` in `OnRotationTimerTick`, which fires every 200 ms while optimizing. Each side then waited on the other.

Because `Update` is called from inside the view model's `_lockObject` (`MainViewModel.cs` lines 1717, 1757, 1884), the wedged thread held **both** locks. `MonitorComputer`, `MonitorApp` and `Optimize` all blocked behind it, and `Dispose` could never acquire `_disposeLock` to finish shutting down — which is why the process could only be ended from Task Manager.

`TrayIconShowMemoryUsage` defaults to `false`, and that default routes through the rotation animation, so the default configuration is the affected one.

Fix: render the icon outside all locks and marshal only the assignment to the UI thread through a new non-blocking `InvokeOnUi` helper. `_disposeLock` is gone from `OnRotationTimerTick`.

### Supporting thread-safety fixes

- `_iconRenderLock` serializes GDI reads of the shared `_imageIcon`. Removing `_disposeLock` also removed the incidental serialization of `Icon.ToBitmap()`, and `System.Drawing.Icon` is not thread safe.
- `_currentIconLock` guards the icon swap so two concurrent callers cannot double-dispose, or leave a disposed icon assigned to the tray.
- `Loading` and `Notify` are marshalled. Both are called from background threads and touch `NotifyIcon` members that have thread affinity (`Visible`, `ShowBalloonTip`).
- `StartRotationAnimation` checks `_rotationTimer` **inside** the UI callback, so two concurrent starts cannot both create a timer.
- `StopRotationAnimation` no longer reads `_rotationTimer` from the calling thread. That field is UI-thread-owned and not volatile, so a background caller could stale-read `null`, skip the cleanup and leave the animation running forever.
- `Dispose` routes timer cleanup through the UI thread. `DispatcherTimer` has thread affinity, so `Stop()` from another thread threw and left the timer firing during shutdown.

### The busy-spin

Both monitor loops did this:

```csharp
if (IsBusy)
    continue;        // skips the WaitOne below

if (token.WaitHandle.WaitOne(60000))
    break;
```

When `IsBusy` was set, `continue` skipped the delay, so the loop spun as fast as the CPU allowed for the whole duration of an optimization. The delay now runs unconditionally. Original timing is preserved: `MonitorApp` still waits 60 s before its first update, and `MonitorComputer` still does work-then-delay so the initial memory readout is not postponed.

Also in `MainViewModel`: the `CancellationToken` is captured once, and `Dispose` no longer disposes the `CancellationTokenSource` while the loops still hold its token — that threw `ObjectDisposedException` from the `while` condition, which sits outside the `try` block and would take down a pool thread.

`ViewModel._isBusy` is now `volatile`: written on the UI thread, polled by the background loops.

### Other

- `MainWindow.OnOptimizeCommandCompleted`: `Thread.Sleep(1000)` on the UI thread replaced with a `DispatcherTimer`, so the grace period no longer freezes the window. **Note: this duplicates part of #184.** I kept it so this PR stands alone, but happy to drop it if #184 lands first.
- `App.Shutdown` is marshalled to the UI thread and arms an 8 s watchdog that force-exits if a graceful shutdown stalls. Defensive only.

## Checklist

- [x] My code follows the project's coding style and conventions.
- [x] I have tested the changes locally.
- [ ] I have updated documentation if necessary — no user-facing behavior change.
- [x] This PR does not introduce any breaking changes.
- [x] I have added unit tests if applicable.

## Testing

Built Release and ran the suite: **342 tests, 0 failures, 0 errors** (up from 339; three added).

Runtime check on the patched build, 227 s sample window with several manual optimizations:

- `Responding=False` occurrences: **0**
- Idle CPU: **0.24 %** of one core
- After each optimization, CPU returns to **0.0 %** with no residual spin

Three regression tests added to `NotificationServiceTests`: concurrent `Update` from 8 threads, `Update` racing `Dispose`, and `Loading` from a background thread.

**Limits of these tests, stated plainly:** they guard against hangs, exceptions and reintroduced blocking, but they do **not** reproduce the original deadlock — that needs a real `WpfApplication`, which can only be constructed once per process and would pollute the suite. I also verified they do not catch the icon-swap race: reverting `_currentIconLock` leaves them all passing. That lock is reasoned hardening, not test-proven.

## Additional Notes

**I don't think this closes #183 entirely.** Several comments there report a different signature: `"Not enough quota is available to process this command."` from `OnDispatcherUnhandledException`, and the tray icon *disappearing while the process keeps running*. That reads like USER-object or desktop-heap exhaustion rather than a deadlock, and a deadlocked UI thread would not produce a dispatcher exception. Marshalling `Notify` (which toggled `NotifyIcon.Visible` from pool threads) may help, but I have not reproduced or confirmed that mechanism, so I'd treat it as an open, separate defect.

I also noticed #195 touches `NotificationService.cs` and `MainViewModel.cs` and lists `Closes #183`. As far as I can tell its changes are caching and lock granularity and do not break the `_disposeLock` ↔ dispatcher cycle above, so these may be complementary rather than competing — but you'll know better than I do. Happy to rebase on whichever lands first.

Environment note: no Visual Studio on my machine, so I built with MSBuild v4 (for the WPF XAML targets) plus `Microsoft.Net.Compilers` 3.11.0, against the restored `packages.config` set. Worth a CI confirmation.
