### PR TITLE
fix: report native status and privilege errors accurately

### DIFF
--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -156,7 +156,15 @@ namespace WinMemoryCleaner
             public static class SystemErrorCode
             {
                 public const int ErrorAccessDenied = 5; // (ERROR_ACCESS_DENIED) Access is denied
+                public const int ErrorInvalidParameter = 87; // (ERROR_INVALID_PARAMETER) The parameter is incorrect
+                public const int ErrorNotAllAssigned = 1300; // (ERROR_NOT_ALL_ASSIGNED) Not all privileges or groups referenced are assigned to the caller
                 public const int ErrorSuccess = 0; // (ERROR_SUCCESS) The operation completed successfully
+            }
+
+            public static class NtStatus
+            {
+                public const int StatusAccessDenied = unchecked((int)0xC0000022);
+                public const int StatusInvalidParameter = unchecked((int)0xC000000D);
             }
 
             public static class SystemInformationClass

--- a/src/Interop/NativeMethods.cs
+++ b/src/Interop/NativeMethods.cs
@@ -74,6 +74,9 @@ namespace WinMemoryCleaner
         [DllImport("ntdll.dll", SetLastError = true)]
         internal static extern int NtSetSystemInformation(int SystemInformationClass, IntPtr SystemInformation, uint SystemInformationLength);
 
+        [DllImport("ntdll.dll")]
+        internal static extern uint RtlNtStatusToDosError(int status);
+
         [DllImport("user32.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool RegisterHotKey(IntPtr hWnd, int id, uint fsModifiers, uint vk);

--- a/src/Service/ComputerService.cs
+++ b/src/Service/ComputerService.cs
@@ -113,6 +113,7 @@ namespace WinMemoryCleaner
         private bool SetIncreasePrivilege(string privilegeName)
         {
             var result = false;
+            var lastWin32Error = Constants.Windows.SystemErrorCode.ErrorSuccess;
 
             using (var current = WindowsIdentity.GetCurrent(TokenAccessLevels.Query | TokenAccessLevels.AdjustPrivileges))
             {
@@ -125,14 +126,30 @@ namespace WinMemoryCleaner
                 if (NativeMethods.LookupPrivilegeValue(null, privilegeName, ref newState.Luid))
                 {
                     // Enables or disables privileges in a specified access token
-                    result = NativeMethods.AdjustTokenPrivileges(current.Token, false, ref newState, 0, IntPtr.Zero, IntPtr.Zero);
+                    var privilegesAdjusted = NativeMethods.AdjustTokenPrivileges(current.Token, false, ref newState, 0, IntPtr.Zero, IntPtr.Zero);
+                    lastWin32Error = Marshal.GetLastWin32Error();
+                    result = IsAdjustTokenPrivilegesSuccessful(privilegesAdjusted, lastWin32Error);
+                }
+                else
+                {
+                    lastWin32Error = Marshal.GetLastWin32Error();
                 }
 
                 if (!result)
-                    Logger.Error(new Win32Exception(Marshal.GetLastWin32Error()));
+                    Logger.Error(new Win32Exception(lastWin32Error));
             }
 
             return result;
+        }
+
+        internal static Win32Exception CreateNtStatusException(int ntStatus)
+        {
+            return new Win32Exception((int)NativeMethods.RtlNtStatusToDosError(ntStatus));
+        }
+
+        internal static bool IsAdjustTokenPrivilegesSuccessful(bool privilegesAdjusted, int lastWin32Error)
+        {
+            return privilegesAdjusted && lastWin32Error == Constants.Windows.SystemErrorCode.ErrorSuccess;
         }
 
         #endregion
@@ -474,8 +491,9 @@ namespace WinMemoryCleaner
 
                 handle = GCHandle.Alloc(memoryCombineInformationEx, GCHandleType.Pinned);
 
-                if (NativeMethods.NtSetSystemInformation(Constants.Windows.SystemInformationClass.SystemCombinePhysicalMemoryInformation, handle.AddrOfPinnedObject(), (uint)Marshal.SizeOf(memoryCombineInformationEx)) != Constants.Windows.SystemErrorCode.ErrorSuccess)
-                    throw new Win32Exception(Marshal.GetLastWin32Error());
+                var status = NativeMethods.NtSetSystemInformation(Constants.Windows.SystemInformationClass.SystemCombinePhysicalMemoryInformation, handle.AddrOfPinnedObject(), (uint)Marshal.SizeOf(memoryCombineInformationEx));
+                if (status != Constants.Windows.SystemErrorCode.ErrorSuccess)
+                    throw CreateNtStatusException(status);
             }
             finally
             {
@@ -590,8 +608,9 @@ namespace WinMemoryCleaner
 
             try
             {
-                if (NativeMethods.NtSetSystemInformation(Constants.Windows.SystemInformationClass.SystemMemoryListInformation, handle.AddrOfPinnedObject(), (uint)Marshal.SizeOf(Constants.Windows.SystemMemoryListCommand.MemoryFlushModifiedList)) != Constants.Windows.SystemErrorCode.ErrorSuccess)
-                    throw new Win32Exception(Marshal.GetLastWin32Error());
+                var status = NativeMethods.NtSetSystemInformation(Constants.Windows.SystemInformationClass.SystemMemoryListInformation, handle.AddrOfPinnedObject(), (uint)Marshal.SizeOf(Constants.Windows.SystemMemoryListCommand.MemoryFlushModifiedList));
+                if (status != Constants.Windows.SystemErrorCode.ErrorSuccess)
+                    throw CreateNtStatusException(status);
             }
             finally
             {
@@ -616,8 +635,9 @@ namespace WinMemoryCleaner
             if (!OperatingSystem.HasRegistryHive)
                 throw new Exception(string.Format(Localizer.Culture, Localizer.String.ErrorMemoryAreaOptimizationNotSupported, Localizer.String.RegistryCache));
 
-            if (NativeMethods.NtSetSystemInformation(Constants.Windows.SystemInformationClass.SystemRegistryReconciliationInformation, IntPtr.Zero, 0) != Constants.Windows.SystemErrorCode.ErrorSuccess)
-                throw new Win32Exception(Marshal.GetLastWin32Error());
+            var status = NativeMethods.NtSetSystemInformation(Constants.Windows.SystemInformationClass.SystemRegistryReconciliationInformation, IntPtr.Zero, 0);
+            if (status != Constants.Windows.SystemErrorCode.ErrorSuccess)
+                throw CreateNtStatusException(status);
         }
 
         /// <summary>
@@ -639,8 +659,9 @@ namespace WinMemoryCleaner
 
             try
             {
-                if (NativeMethods.NtSetSystemInformation(Constants.Windows.SystemInformationClass.SystemMemoryListInformation, handle.AddrOfPinnedObject(), (uint)Marshal.SizeOf(memoryPurgeStandbyList)) != Constants.Windows.SystemErrorCode.ErrorSuccess)
-                    throw new Win32Exception(Marshal.GetLastWin32Error());
+                var status = NativeMethods.NtSetSystemInformation(Constants.Windows.SystemInformationClass.SystemMemoryListInformation, handle.AddrOfPinnedObject(), (uint)Marshal.SizeOf(memoryPurgeStandbyList));
+                if (status != Constants.Windows.SystemErrorCode.ErrorSuccess)
+                    throw CreateNtStatusException(status);
             }
             finally
             {
@@ -682,8 +703,9 @@ namespace WinMemoryCleaner
 
                 handle = GCHandle.Alloc(systemFileCacheInformation, GCHandleType.Pinned);
 
-                if (NativeMethods.NtSetSystemInformation(Constants.Windows.SystemInformationClass.SystemFileCacheInformation, handle.AddrOfPinnedObject(), (uint)Marshal.SizeOf(systemFileCacheInformation)) != Constants.Windows.SystemErrorCode.ErrorSuccess)
-                    throw new Win32Exception(Marshal.GetLastWin32Error());
+                var status = NativeMethods.NtSetSystemInformation(Constants.Windows.SystemInformationClass.SystemFileCacheInformation, handle.AddrOfPinnedObject(), (uint)Marshal.SizeOf(systemFileCacheInformation));
+                if (status != Constants.Windows.SystemErrorCode.ErrorSuccess)
+                    throw CreateNtStatusException(status);
             }
             finally
             {
@@ -751,15 +773,16 @@ namespace WinMemoryCleaner
             {
                 // Check privilege
                 if (!SetIncreasePrivilege(Constants.Windows.Privilege.SeProfSingleProcessName))
-                    throw new Exception(string.Format(Localizer.Culture, Localizer.String.ErrorAdminPrivilegeRequired, Constants.Windows.Privilege.SeDebugName));
+                    throw new Exception(string.Format(Localizer.Culture, Localizer.String.ErrorAdminPrivilegeRequired, Constants.Windows.Privilege.SeProfSingleProcessName));
 
                 var handle = GCHandle.Alloc(Constants.Windows.SystemMemoryListCommand.MemoryEmptyWorkingSets, GCHandleType.Pinned);
 
                 try
                 {
-                    if (NativeMethods.NtSetSystemInformation(Constants.Windows.SystemInformationClass.SystemMemoryListInformation, handle.AddrOfPinnedObject(), (uint)Marshal.SizeOf(Constants.Windows.SystemMemoryListCommand.MemoryEmptyWorkingSets)) != Constants.Windows.SystemErrorCode.ErrorSuccess)
+                    var status = NativeMethods.NtSetSystemInformation(Constants.Windows.SystemInformationClass.SystemMemoryListInformation, handle.AddrOfPinnedObject(), (uint)Marshal.SizeOf(Constants.Windows.SystemMemoryListCommand.MemoryEmptyWorkingSets));
+                    if (status != Constants.Windows.SystemErrorCode.ErrorSuccess)
                     {
-                        var e = new Win32Exception(Marshal.GetLastWin32Error());
+                        var e = CreateNtStatusException(status);
 
                         if (e != null)
                         {

--- a/src/Test/NativeMemoryInteropTests.cs
+++ b/src/Test/NativeMemoryInteropTests.cs
@@ -1,0 +1,68 @@
+using NUnit.Framework;
+
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+namespace WinMemoryCleaner.NativeMemoryTests
+{
+    [TestFixture]
+    public sealed class NativeMemoryInteropTests
+    {
+        [Test]
+        public void CreateNtStatusException_WhenStatusIsAccessDenied_MapsToWin32AccessDenied()
+        {
+            var exception = ComputerService.CreateNtStatusException(Constants.Windows.NtStatus.StatusAccessDenied);
+
+            Assert.AreEqual(Constants.Windows.SystemErrorCode.ErrorAccessDenied, exception.NativeErrorCode);
+        }
+
+        [Test]
+        public void CreateNtStatusException_WhenStatusIsInvalidParameter_MapsWithoutStaleWin32Error()
+        {
+            var exception = ComputerService.CreateNtStatusException(Constants.Windows.NtStatus.StatusInvalidParameter);
+
+            Assert.AreEqual(Constants.Windows.SystemErrorCode.ErrorInvalidParameter, exception.NativeErrorCode);
+        }
+
+        [Test]
+        public void IsAdjustTokenPrivilegesSuccessful_WhenNativeCallAndLastErrorSucceed_ReturnsTrue()
+        {
+            Assert.IsTrue(ComputerService.IsAdjustTokenPrivilegesSuccessful(
+                true,
+                Constants.Windows.SystemErrorCode.ErrorSuccess));
+        }
+
+        [Test]
+        public void IsAdjustTokenPrivilegesSuccessful_WhenNotAllPrivilegesAreAssigned_ReturnsFalse()
+        {
+            Assert.IsFalse(ComputerService.IsAdjustTokenPrivilegesSuccessful(
+                true,
+                Constants.Windows.SystemErrorCode.ErrorNotAllAssigned));
+        }
+
+        [Test]
+        public void IsAdjustTokenPrivilegesSuccessful_WhenNativeCallSucceedsWithError_ReturnsFalse()
+        {
+            Assert.IsFalse(ComputerService.IsAdjustTokenPrivilegesSuccessful(
+                true,
+                Constants.Windows.SystemErrorCode.ErrorAccessDenied));
+        }
+
+        [Test]
+        public void IsAdjustTokenPrivilegesSuccessful_WhenNativeCallFailsWithSuccessError_ReturnsFalse()
+        {
+            Assert.IsFalse(ComputerService.IsAdjustTokenPrivilegesSuccessful(
+                false,
+                Constants.Windows.SystemErrorCode.ErrorSuccess));
+        }
+
+        [Test]
+        public void IsAdjustTokenPrivilegesSuccessful_WhenNativeCallFailsWithError_ReturnsFalse()
+        {
+            Assert.IsFalse(ComputerService.IsAdjustTokenPrivilegesSuccessful(
+                false,
+                Constants.Windows.SystemErrorCode.ErrorAccessDenied));
+        }
+    }
+}
+
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member

--- a/src/WinMemoryCleaner.csproj
+++ b/src/WinMemoryCleaner.csproj
@@ -163,6 +163,7 @@
     <Compile Include="Test\CoreTests.cs" />
     <Compile Include="Test\IntegrationTests.cs" />
     <Compile Include="Test\Mocker.cs" />
+    <Compile Include="Test\NativeMemoryInteropTests.cs" />
     <Compile Include="Test\ModelTests.cs" />
     <Compile Include="Test\ServiceTests.cs" />
     <Compile Include="Test\TestCleanup.cs" />


### PR DESCRIPTION
## Summary
Report native memory-operation failures using the correct Windows error semantics. This independent contribution is based on upstream `main`; candidate commit: `16f2026`.

## Related Issue
No exact issue identified. The two GCHandle initialization fixes already proposed in #195 and #203 are intentionally excluded to avoid duplicating that work.

## Changes
- Convert NTSTATUS through `RtlNtStatusToDosError` instead of reading unrelated last-error state.
- Require both a successful `AdjustTokenPrivileges` call and `ERROR_SUCCESS`; capture the error immediately.
- Correct the working-set privilege name in its diagnostic.
- Add seven focused regression tests for status mapping and privilege-result combinations.

## Checklist
- [x] My code follows the project’s coding style and conventions.
- [ ] I have tested the changes locally.
- [x] I have updated documentation if necessary. No user-facing configuration change is introduced.
- [x] This PR does not introduce any breaking changes.
- [x] I have added unit tests if applicable.

## Additional Notes
[Standalone hosted Windows validation](https://github.com/MataM15/WinMemoryCleaner/actions/runs/34000735924): Release build with 0 warnings and 0 errors; all 7 selected NUnit tests passed on this exact candidate. These are focused tests, not a claim that the entire suite or live cleanup scenarios were exercised.

The fork-only validation workflow, benchmark, packaging tools, and unrelated fork changes are not included. Scope: 5 files, 133 changed lines.