### PR TITLE
refactor: share automatic optimization trigger policy

### DIFF
--- a/src/Core/AutoOptimizationPolicy.cs
+++ b/src/Core/AutoOptimizationPolicy.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace WinMemoryCleaner
+{
+    internal static class AutoOptimizationPolicy
+    {
+        internal static Enums.Memory.Optimization.Reason? GetReason(
+            DateTimeOffset now,
+            DateTimeOffset lastAutoOptimizationByInterval,
+            DateTimeOffset lastAutoOptimizationByMemoryUsage,
+            int autoOptimizationInterval,
+            int autoOptimizationMemoryUsage,
+            int freePhysicalMemoryPercentage)
+        {
+            if (autoOptimizationInterval > 0 &&
+                now.Subtract(lastAutoOptimizationByInterval).TotalHours >= autoOptimizationInterval)
+            {
+                return Enums.Memory.Optimization.Reason.Schedule;
+            }
+
+            if (autoOptimizationMemoryUsage > 0 &&
+                freePhysicalMemoryPercentage < autoOptimizationMemoryUsage &&
+                now.Subtract(lastAutoOptimizationByMemoryUsage).TotalMinutes >= Constants.App.AutoOptimizationMemoryUsageInterval)
+            {
+                return Enums.Memory.Optimization.Reason.LowMemory;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Test/AutoOptimizationPolicyTests.cs
+++ b/src/Test/AutoOptimizationPolicyTests.cs
@@ -1,0 +1,103 @@
+using NUnit.Framework;
+using System;
+
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+namespace WinMemoryCleaner.AutomationTests
+{
+    [TestFixture]
+    public class AutoOptimizationPolicyTests
+    {
+        [Test]
+        public void DisabledBoth_ReturnsNull()
+        {
+            var now = new DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero);
+
+            var result = AutoOptimizationPolicy.GetReason(now, now.AddHours(-24), now.AddMinutes(-30), 0, 0, 0);
+
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public void Schedule_WhenJustBeforeDue_ReturnsNull()
+        {
+            var now = new DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero);
+
+            var result = AutoOptimizationPolicy.GetReason(now, now.AddHours(-1).AddTicks(1), now, 1, 0, 0);
+
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public void Schedule_WhenExactlyDue_ReturnsSchedule()
+        {
+            var now = new DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero);
+
+            var result = AutoOptimizationPolicy.GetReason(now, now.AddHours(-1), now, 1, 0, 0);
+
+            Assert.AreEqual(Enums.Memory.Optimization.Reason.Schedule, result);
+        }
+
+        [Test]
+        public void LowMemory_WhenFreePercentageIsBelowThreshold_ReturnsLowMemory()
+        {
+            var now = new DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero);
+
+            var result = AutoOptimizationPolicy.GetReason(now, now, now.AddMinutes(-Constants.App.AutoOptimizationMemoryUsageInterval), 0, 40, 39);
+
+            Assert.AreEqual(Enums.Memory.Optimization.Reason.LowMemory, result);
+        }
+
+        [Test]
+        public void LowMemory_WhenFreePercentageEqualsThreshold_ReturnsNull()
+        {
+            var now = new DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero);
+
+            var result = AutoOptimizationPolicy.GetReason(now, now, now.AddMinutes(-Constants.App.AutoOptimizationMemoryUsageInterval), 0, 40, 40);
+
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public void LowMemory_WhenCooldownIsJustBeforeDue_ReturnsNull()
+        {
+            var now = new DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero);
+
+            var result = AutoOptimizationPolicy.GetReason(now, now, now.AddMinutes(-Constants.App.AutoOptimizationMemoryUsageInterval).AddTicks(1), 0, 40, 39);
+
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public void LowMemory_WhenCooldownIsExactlyDue_ReturnsLowMemory()
+        {
+            var now = new DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero);
+
+            var result = AutoOptimizationPolicy.GetReason(now, now, now.AddMinutes(-Constants.App.AutoOptimizationMemoryUsageInterval), 0, 40, 39);
+
+            Assert.AreEqual(Enums.Memory.Optimization.Reason.LowMemory, result);
+        }
+
+        [Test]
+        public void Schedule_WhenBothTriggersAreDue_ReturnsSchedule()
+        {
+            var now = new DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero);
+
+            var result = AutoOptimizationPolicy.GetReason(now, now.AddHours(-1), now.AddMinutes(-Constants.App.AutoOptimizationMemoryUsageInterval), 1, 40, 39);
+
+            Assert.AreEqual(Enums.Memory.Optimization.Reason.Schedule, result);
+        }
+
+        [Test]
+        public void Schedule_WhenNonZeroIntervalCrossesDateBoundary_ReturnsSchedule()
+        {
+            var now = new DateTimeOffset(2024, 1, 2, 0, 0, 0, TimeSpan.Zero);
+
+            var result = AutoOptimizationPolicy.GetReason(now, now.AddHours(-7), now, 7, 35, 100);
+
+            Assert.AreEqual(Enums.Memory.Optimization.Reason.Schedule, result);
+        }
+    }
+}
+
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member

--- a/src/ViewModel/MainViewModel.cs
+++ b/src/ViewModel/MainViewModel.cs
@@ -1636,24 +1636,23 @@ namespace WinMemoryCleaner
                     {
                         if (CanOptimize)
                         {
-                            // Interval
-                            if (Settings.AutoOptimizationInterval > 0 &&
-                                DateTimeOffset.Now.Subtract(_lastAutoOptimizationByInterval).TotalHours >= Settings.AutoOptimizationInterval)
+                            var reason = AutoOptimizationPolicy.GetReason(
+                                DateTimeOffset.Now,
+                                _lastAutoOptimizationByInterval,
+                                _lastAutoOptimizationByMemoryUsage,
+                                Settings.AutoOptimizationInterval,
+                                Settings.AutoOptimizationMemoryUsage,
+                                Computer.Memory.Physical.Free.Percentage);
+
+                            if (reason.HasValue)
                             {
-                                OptimizeAsync(Enums.Memory.Optimization.Reason.Schedule);
+                                OptimizeAsync(reason.Value);
 
-                                _lastAutoOptimizationByInterval = DateTimeOffset.Now;
-                                continue;
-                            }
+                                if (reason.Value == Enums.Memory.Optimization.Reason.Schedule)
+                                    _lastAutoOptimizationByInterval = DateTimeOffset.Now;
+                                else
+                                    _lastAutoOptimizationByMemoryUsage = DateTimeOffset.Now;
 
-                            // Memory usage
-                            if (Settings.AutoOptimizationMemoryUsage > 0 &&
-                                Computer.Memory.Physical.Free.Percentage < Settings.AutoOptimizationMemoryUsage &&
-                                DateTimeOffset.Now.Subtract(_lastAutoOptimizationByMemoryUsage).TotalMinutes >= Constants.App.AutoOptimizationMemoryUsageInterval)
-                            {
-                                OptimizeAsync(Enums.Memory.Optimization.Reason.LowMemory);
-
-                                _lastAutoOptimizationByMemoryUsage = DateTimeOffset.Now;
                                 continue;
                             }
                         }

--- a/src/WinMemoryCleaner.csproj
+++ b/src/WinMemoryCleaner.csproj
@@ -118,6 +118,7 @@
     <Compile Include="Converters\PercentageToWidthConverter.cs" />
     <Compile Include="Converters\StringFormatConverter.cs" />
     <Compile Include="Converters\SumNumericConverter.cs" />
+    <Compile Include="Core\AutoOptimizationPolicy.cs" />
     <Compile Include="Core\Constants.cs" />
     <Compile Include="Core\DependencyInjection.cs" />
     <Compile Include="Core\Enums.cs" />
@@ -158,6 +159,7 @@
     <Compile Include="Service\ComputerService.cs" />
     <Compile Include="Service\HotkeyService.cs" />
     <Compile Include="Service\NotificationService.cs" />
+    <Compile Include="Test\AutoOptimizationPolicyTests.cs" />
     <Compile Include="Test\CommandTests.cs" />
     <Compile Include="Test\ConverterTests.cs" />
     <Compile Include="Test\CoreTests.cs" />

--- a/src/WindowsService/WinService.cs
+++ b/src/WindowsService/WinService.cs
@@ -116,24 +116,23 @@ namespace WinMemoryCleaner
             // Update memory info
             _computer.Memory = _computerService.Memory;
 
-            // Interval
-            if (Settings.AutoOptimizationInterval > 0 &&
-                DateTimeOffset.Now.Subtract(_lastAutoOptimizationByInterval).TotalHours >= Settings.AutoOptimizationInterval)
+            var reason = AutoOptimizationPolicy.GetReason(
+                DateTimeOffset.Now,
+                _lastAutoOptimizationByInterval,
+                _lastAutoOptimizationByMemoryUsage,
+                Settings.AutoOptimizationInterval,
+                Settings.AutoOptimizationMemoryUsage,
+                _computer.Memory.Physical.Free.Percentage);
+
+            if (reason.HasValue)
             {
-                DependencyInjection.Container.Resolve<IComputerService>().Optimize(Enums.Memory.Optimization.Reason.Schedule, Settings.MemoryAreas);
+                DependencyInjection.Container.Resolve<IComputerService>().Optimize(reason.Value, Settings.MemoryAreas);
 
-                _lastAutoOptimizationByInterval = DateTimeOffset.Now;
-                return;
-            }
+                if (reason.Value == Enums.Memory.Optimization.Reason.Schedule)
+                    _lastAutoOptimizationByInterval = DateTimeOffset.Now;
+                else
+                    _lastAutoOptimizationByMemoryUsage = DateTimeOffset.Now;
 
-            // Memory usage
-            if (Settings.AutoOptimizationMemoryUsage > 0 &&
-                _computer.Memory.Physical.Free.Percentage < Settings.AutoOptimizationMemoryUsage &&
-                DateTimeOffset.Now.Subtract(_lastAutoOptimizationByMemoryUsage).TotalMinutes >= Constants.App.AutoOptimizationMemoryUsageInterval)
-            {
-                DependencyInjection.Container.Resolve<IComputerService>().Optimize(Enums.Memory.Optimization.Reason.LowMemory, Settings.MemoryAreas);
-
-                _lastAutoOptimizationByMemoryUsage = DateTimeOffset.Now;
                 return;
             }
         }


### PR DESCRIPTION
## Summary
Share automatic-optimization trigger selection between the GUI and Windows service while preserving existing behavior. This independent contribution is based on upstream `main`; candidate commit: `516907a`.

## Related Issue
No exact issue identified.

## Changes
- Extract a pure `AutoOptimizationPolicy` helper used by both hosts.
- Preserve schedule priority, the strict low-memory threshold comparison, and the five-minute cooldown boundary.
- Keep host dispatch, timestamp updates, and concurrency behavior unchanged.
- Add nine focused boundary tests.

## Checklist
- [x] My code follows the project’s coding style and conventions.
- [ ] I have tested the changes locally.
- [x] I have updated documentation if necessary. No new behavior or configuration is introduced.
- [x] This PR does not introduce any breaking changes.
- [x] I have added unit tests if applicable.

## Additional Notes
[Standalone hosted Windows validation](https://github.com/MataM15/WinMemoryCleaner/actions/runs/34000752924): Release build with 0 warnings and 0 errors; all 9 selected NUnit tests passed. A compiled threshold mutant produced the expected 3 failures; the source bytes were restored and hash-checked, followed by a successful rebuild and 9 passing tests.

The mutation script and validation workflow remain fork-only and are not part of this PR. This is not a concurrency change or a claim of full-suite coverage. Scope: 5 files, 194 changed lines.